### PR TITLE
RTO fixes 

### DIFF
--- a/TCP Cubic/TcpCubic.cc
+++ b/TCP Cubic/TcpCubic.cc
@@ -229,7 +229,7 @@ void TcpCubic::cubic_update()
 }
 
 
-void TcpCubic::performSSCA()
+void TcpCubic::performSSCA(uint32_t firstSeqAcked)
 {
     if (state->snd_cwnd <= state->ssthresh) {
         EV_DETAIL << "cwnd <= ssthresh: Slow Start: increasing cwnd by SMSS bytes to ";
@@ -455,7 +455,7 @@ void TcpCubic::receivedDataAck(uint32_t firstSeqAcked)
     else
     {
         // Perform slow start and congestion avoidance.
-        performSSCA();
+        performSSCA(firstSeqAcked);
 
         // RFC 3782, page 13:
         // "When not in Fast Recovery, the value of the state variable "recover"

--- a/TCP Cubic/TcpCubic.cc
+++ b/TCP Cubic/TcpCubic.cc
@@ -45,7 +45,7 @@ void TcpCubic::initialize()
 {
     TcpBaseAlg::initialize();
     cubic_reset();
-    state->c_litle_b = 0.2;
+    state->c_litle_b = 0.3;
     state->c_big_C = 0.4;
     state->c_tcp_friendliness = 1;
     state->c_fast_convergence = 1;

--- a/TCP Cubic/TcpCubic.cc
+++ b/TCP Cubic/TcpCubic.cc
@@ -72,6 +72,11 @@ void TcpCubic::recalculateSlowStartThreshold()
 
 void TcpCubic::processRexmitTimer(TcpEventCode& event)
 {
+    // deflate the congestion window to prevent the new ssthresh calculation to use the inflated value
+    if(state->lossRecovery){
+        state->snd_cwnd = state->ssthresh;
+    } 
+    
     TcpBaseAlg::processRexmitTimer(event);
 
     if (event == TCP_E_ABORT)
@@ -342,7 +347,7 @@ void TcpCubic::receivedDataAck(uint32_t firstSeqAcked)
         }
     }
     // srg c v end
-    
+
 
     const TcpSegmentTransmitInfoList::Item *found = state->regions.get(firstSeqAcked);
 

--- a/TCP Cubic/TcpCubic.h
+++ b/TCP Cubic/TcpCubic.h
@@ -40,7 +40,7 @@ class INET_API TcpCubic : public TcpBaseAlg
 
         virtual void initialize() override;
 
-        void performSSCA();
+        void performSSCA(uint32_t firstSeqAcked);
 
         void cubic_reset();
 

--- a/TCP Cubic/TcpCubic.h
+++ b/TCP Cubic/TcpCubic.h
@@ -25,6 +25,8 @@ class INET_API TcpCubic : public TcpBaseAlg
 
         TcpCubicStateVariables *& state; // alias to TCLAlgorithm's 'state'
 
+        bool _abc; // use apropriate byte counting in the slow start phase
+
         virtual TcpStateVariables *createStateVariables() override
         {
             return new TcpCubicStateVariables();

--- a/TCP Cubic/TcpCubicState.msg
+++ b/TCP Cubic/TcpCubicState.msg
@@ -27,6 +27,7 @@ struct TcpCubicStateVariables extends TcpBaseAlgStateVariables
     TcpSegmentTransmitInfoList regions;
 
     uint32_t ssthresh = 4294967295; ///< slow start threshold
+    bool inhibitRecovery = false; // for wrap around protection
 
     ///cubic variables
     uint32_t c_w_last_max;


### PR DESCRIPTION
- timer management in the base class is currently not differentiating between partial and full ACKs.
- ssthresh calculation used the inflated cwnd after a RTO
- recover threshold was reset after RTO where it should not have by the procedure to prevent problems on sequence number wrap arounds
- added Appropriate Byte Counting (ABC)
- changed cubic_beta to match the current rfc